### PR TITLE
Add account sid selector to speech form

### DIFF
--- a/src/components/elements/FileUpload.js
+++ b/src/components/elements/FileUpload.js
@@ -46,6 +46,38 @@ const StyledInput = styled.input`
   &:active:not([disabled]):after {
     background: #A40D40;
   }
+
+  &::file-selector-button {
+    content: '${props => props.validFile ? 'Choose a Different File' : 'Choose File'}';
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 2.25rem;
+    top: 0;
+    left: 0;
+    padding: 0 1rem;
+    border-radius: 0.25rem;
+    background: #D91C5C;
+    color: #FFF;
+    font-weight: 500;
+    cursor: pointer;
+    outline: 0;
+    border: 0;
+  }
+
+  &:focus::file-selector-button {
+    box-shadow: 0 0.125rem 0.25rem rgba(0,0,0,0.12),
+                inset 0 0 0 0.25rem #890934;
+  }
+
+  &:hover:not([disabled])::file-selector-button {
+    background: #BD164E;
+  }
+
+  &:active:not([disabled])::file-selector-button {
+    background: #A40D40;
+  }
 `;
 
 const FileUpload = (props, ref) => {

--- a/src/components/forms/CarrierForm.js
+++ b/src/components/forms/CarrierForm.js
@@ -765,7 +765,11 @@ const CarrierForm = (props) => {
       }
 
       isMounted = false;
-      history.push('/internal/carriers');
+      if (accountSid) {
+        history.push(`/internal/carriers?account_sid=${accountSid}`);
+      } else {
+        history.push('/internal/carriers');
+      }
       const dispatchMessage = type === 'add'
         ? 'Carrier created successfully'
         : 'Carrier updated successfully';

--- a/src/components/forms/SpeechForm.js
+++ b/src/components/forms/SpeechForm.js
@@ -400,7 +400,11 @@ const SpeechServicesAddEdit = (props) => {
       // If successful, go to speech services
       //===============================================
       isMounted = false;
-      history.push('/internal/speech-services');
+      if (accountSid) {
+        history.push(`/internal/speech-services?account_sid=${accountSid}`);
+      } else {
+        history.push('/internal/speech-services');
+      }
       const dispatchMessage = type === 'add'
         ? 'Speech service created successfully'
         : 'Speech service updated successfully';

--- a/src/components/forms/SpeechForm.js
+++ b/src/components/forms/SpeechForm.js
@@ -253,33 +253,6 @@ const SpeechServicesAddEdit = (props) => {
         return;
       }
 
-      // Check if user already has a speech service with the selected vendor
-      const speechServices = await axios({
-        method: 'get',
-        baseURL: process.env.REACT_APP_API_BASE_URL,
-        url: `/ServiceProviders/${currentServiceProvider}/SpeechCredentials`,
-        headers: {
-          Authorization: `Bearer ${jwt}`,
-        },
-      });
-
-      if (type === 'add' && speechServices.data.some(speech => speech.vendor === vendor)) {
-        setErrorMessage('You can only have one speech credential per vendor.');
-        setShowLoader(false);
-        if (vendor === 'google') {
-          setInvalidVendorGoogle(true);
-          if (!focusHasBeenSet) {
-            refVendorGoogle.current.focus();
-          }
-        } else if (vendor === 'aws') {
-          setInvalidVendorAws(true);
-          if (!focusHasBeenSet) {
-            refVendorAws.current.focus();
-          }
-        }
-        return;
-      }
-
       //===============================================
       // Submit
       //===============================================

--- a/src/components/pages/internal/SpeechServicesList.js
+++ b/src/components/pages/internal/SpeechServicesList.js
@@ -101,23 +101,17 @@ const SpeechServicesList = () => {
 
       if(!currentServiceProvider) return [];
 
-      const speechServices = accountSid ? 
-        await axios({
-          method: 'get',
-          baseURL: process.env.REACT_APP_API_BASE_URL,
-          url: `/Accounts/${accountSid}/SpeechCredentials`,
-          headers: {
-            Authorization: `Bearer ${jwt}`,
-          },
-        }) :
-        await axios({
-          method: 'get',
-          baseURL: process.env.REACT_APP_API_BASE_URL,
-          url: `/ServiceProviders/${currentServiceProvider}/SpeechCredentials`,
-          headers: {
-            Authorization: `Bearer ${jwt}`,
-          },
-        });
+      const speechApiUrl = accountSid ? 
+        `/Accounts/${accountSid}/SpeechCredentials` : 
+        `/ServiceProviders/${currentServiceProvider}/SpeechCredentials`;
+      const speechServices = await axios({
+        method: 'get',
+        baseURL: process.env.REACT_APP_API_BASE_URL,
+        url: speechApiUrl,
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+        },
+      });
 
       const credentialTestPromises = speechServices.data.map(s => {
         if (s.use_for_stt || s.use_for_tts) {

--- a/src/components/pages/internal/SpeechServicesList.js
+++ b/src/components/pages/internal/SpeechServicesList.js
@@ -1,24 +1,93 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useContext, useCallback } from 'react';
-import { useHistory } from 'react-router-dom';
+import React, { useContext, useState, useEffect } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import axios from 'axios';
+import styled from 'styled-components/macro';
+
 import { NotificationDispatchContext } from '../../../contexts/NotificationContext';
 import handleErrors from '../../../helpers/handleErrors';
 import InternalTemplate from '../../templates/InternalTemplate';
 import TableContent from '../../../components/blocks/TableContent';
 import { ServiceProviderValueContext } from '../../../contexts/ServiceProviderContext';
 import Sbcs from '../../blocks/Sbcs';
+import InputGroup from '../../../components/elements/InputGroup';
+import Select from '../../../components/elements/Select';
+
+const FilterLabel = styled.span`
+  color: #231f20;
+  text-align: right;
+  font-size: 14px;
+  margin-left: 1rem;
+  margin-right: 0.5rem;
+`;
+
+const StyledInputGroup = styled(InputGroup)`
+  padding: 1rem 1rem 0;
+
+  @media (max-width: 767.98px) {
+    display: grid;
+    grid-template-columns: auto 1fr auto 1fr;
+    grid-row-gap: 1rem;
+  }
+
+  @media (max-width: 575.98px) {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-row-gap: 1rem;
+  }
+`;
+
+const AccountSelect = styled(Select)`
+  min-width: 150px;
+`;
 
 const SpeechServicesList = () => {
   let history = useHistory();
   const dispatch = useContext(NotificationDispatchContext);
   const currentServiceProvider = useContext(ServiceProviderValueContext);
+  const jwt = localStorage.getItem('token');
+  const location = useLocation();
+  const locationAccountSid = new URLSearchParams(location.search).get('account_sid');
+
+  const [accountSid, setAccountSid] = useState('');
+  const [accountList, setAccountList] = useState([]);
+
+  //=============================================================================
+  // Get accounts
+  //=============================================================================
+  useEffect(() => {
+    if (currentServiceProvider) {
+      const getAccounts = async () => {
+        try {
+          const accountResponse = await axios({
+            method: "get",
+            baseURL: process.env.REACT_APP_API_BASE_URL,
+            url: `/ServiceProviders/${currentServiceProvider}/Accounts`,
+            headers: {
+              Authorization: `Bearer ${jwt}`,
+            },
+          });
+
+          setAccountList((accountResponse.data || []).sort((a, b) => a.name.localeCompare(b.name)));
+
+          if (locationAccountSid) {
+            setAccountSid(locationAccountSid);
+          }
+        } catch (err) {
+          handleErrors({ err, history, dispatch });
+        }
+      };
+
+      getAccounts();
+    } else {
+      setAccountList([]);
+    }
+  }, [currentServiceProvider]);
 
   //=============================================================================
   // Get speech services
   //=============================================================================
-  const getSpeechServices = useCallback(async () => {
-    const jwt = localStorage.getItem('token');
+  const getSpeechServices = async () => {
     try {
       if (!jwt) {
         history.push('/');
@@ -31,14 +100,24 @@ const SpeechServicesList = () => {
       }
 
       if(!currentServiceProvider) return [];
-      const speechServices = await axios({
-        method: 'get',
-        baseURL: process.env.REACT_APP_API_BASE_URL,
-        url: `/ServiceProviders/${currentServiceProvider}/SpeechCredentials`,
-        headers: {
-          Authorization: `Bearer ${jwt}`,
-        },
-      });
+
+      const speechServices = accountSid ? 
+        await axios({
+          method: 'get',
+          baseURL: process.env.REACT_APP_API_BASE_URL,
+          url: `/Accounts/${accountSid}/SpeechCredentials`,
+          headers: {
+            Authorization: `Bearer ${jwt}`,
+          },
+        }) :
+        await axios({
+          method: 'get',
+          baseURL: process.env.REACT_APP_API_BASE_URL,
+          url: `/ServiceProviders/${currentServiceProvider}/SpeechCredentials`,
+          headers: {
+            Authorization: `Bearer ${jwt}`,
+          },
+        });
 
       const credentialTestPromises = speechServices.data.map(s => {
         if (s.use_for_stt || s.use_for_tts) {
@@ -137,7 +216,7 @@ const SpeechServicesList = () => {
     } catch (err) {
       handleErrors({ err, history, dispatch, fallbackMessage: 'Unable to get speech services' });
     }
-  }, [currentServiceProvider]);
+  };
 
   //=============================================================================
   // Delete speech service
@@ -149,8 +228,7 @@ const SpeechServicesList = () => {
       { name: 'Last Used', content: s.last_used || 'Never' },
     ];
   };
-  const deleteSpeechService = useCallback(async speechServiceToDelete => {
-    const jwt = localStorage.getItem('token');
+  const deleteSpeechService = async speechServiceToDelete => {
     try {
       if (!jwt) {
         history.push('/');
@@ -187,7 +265,7 @@ const SpeechServicesList = () => {
         return ((err.response && err.response.data && err.response.data.msg) || 'Unable to delete speech service');
       }
     }
-  }, [currentServiceProvider]);
+  };
 
   //=============================================================================
   // Render
@@ -200,6 +278,22 @@ const SpeechServicesList = () => {
       addButtonText="Add Speech Service"
       addButtonLink="/internal/speech-services/add"
     >
+      <StyledInputGroup flexEnd space>
+        <FilterLabel htmlFor="account">Used By:</FilterLabel>
+        <AccountSelect
+          name="account"
+          id="account"
+          value={accountSid}
+          onChange={e => setAccountSid(e.target.value)}
+        >
+          <option value="">
+            All accounts
+          </option>
+          {accountList.map((acc) => (
+            <option key={acc.account_sid} value={acc.account_sid}>{acc.name}</option>
+          ))}
+        </AccountSelect>
+      </StyledInputGroup>
       <TableContent
         normalTable
         name="speech service"


### PR DESCRIPTION
This PR:

- Adds account selector to speech form
- Sends `account_sid` with payload if selected in speech form
- Otherwise sends `service_provider_sid` with payload if no account is selected in speech form
- Adds account selector to speech credentials list view
- Adds account selector to carrier list view
- Adds file input pseudo element styling for Mozilla so file input button UI is visible in Firefox