### PR TITLE
Add z-index property to Add button

### DIFF
--- a/src/components/elements/AddButton.js
+++ b/src/components/elements/AddButton.js
@@ -21,6 +21,7 @@ const StyledLink = styled(FilteredLink)`
   border-radius: 50%;
   text-decoration: none;
   color: #565656;
+  z-index: 1;
 
   & > span:first-child {
     display: flex;

--- a/src/data/AwsRegions.js
+++ b/src/data/AwsRegions.js
@@ -54,6 +54,38 @@ const regions = [
   {
     name: 'Canada (Central)',
     value: 'ca-central-1'
+  },
+  {
+    name: 'Europe (Frankfurt)',
+    value: 'eu-central-1'
+  },
+  {
+    name: 'Europe (Ireland)',
+    value: 'eu-west-1'
+  },
+  {
+    name: 'Europe (London)',
+    value: 'eu-west-2'
+  },
+  {
+    name: 'Europe (Milan)',
+    value: 'eu-south-1'
+  },
+  {
+    name: 'Europe (Paris)',
+    value: 'eu-west-3'
+  },
+  {
+    name: 'Europe (Stockholm)',
+    value: 'eu-north-1'
+  },
+  {
+    name: 'Middle East (Bahrain)',
+    value: 'me-south-1'
+  },
+  {
+    name: 'South America (São Paulo)',
+    value: 'sa-east-1'
   }
 ];
 


### PR DESCRIPTION
The add button on the internal template can't be clicked because it's under the list component. I've added a z-index CSS property to send it to the top. Doing so the add button can be clicked anywhere down the list and not just at the beggining.