### PR TITLE
remove dummy text from siprec tooltip

### DIFF
--- a/src/components/forms/AccountForm.js
+++ b/src/components/forms/AccountForm.js
@@ -731,9 +731,6 @@ const AccountForm = props => {
               <Label tooltip htmlFor="siprecCallingApplication">
                 <span style={{ position: 'relative' }}>
                   Application for SIPREC Calls
-                  <Tooltip large>
-                    This is a really long sample text to let it show up something
-                  </Tooltip>
                 </span>
               </Label>
               <Select


### PR DESCRIPTION
Not sure why the other one just automatically close, probably I pushed before making a fix commit