### PR TITLE
Add inputs to Carrier form to support outbound registration

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -256,8 +256,11 @@ export interface Carrier {
   e164_leading_plus: boolean;
   requires_register: boolean;
   register_username: null | string;
-  register_sip_realm: null | string;
   register_password: null | string;
+  register_sip_realm: null | string;
+  register_from_user: null | string;
+  register_from_domain: null | string;
+  register_public_ip_in_contact: boolean;
   tech_prefix: null | string;
   diversion: null | string;
   inbound_auth_username: string;

--- a/src/containers/internal/views/carriers/form.tsx
+++ b/src/containers/internal/views/carriers/form.tsx
@@ -90,6 +90,9 @@ export const CarrierForm = ({
   const [sipPass, setSipPass] = useState("");
   const [sipRealm, setSipRealm] = useState("");
   const [initialRegister, setInitialRegister] = useState(false);
+  const [fromUser, setFromUser] = useState("");
+  const [fromDomain, setFromDomain] = useState("");
+  const [regPublicIpInContact, setRegPublicIpInContact] = useState(false);
 
   const [prefix, setPrefix] = useState("");
   const [initialPrefix, setInitialPrefix] = useState(false);
@@ -146,12 +149,24 @@ export const CarrierForm = ({
       if (obj.register_sip_realm) {
         setSipRealm(obj.register_sip_realm);
       }
+      if (obj.register_from_user) {
+        setFromUser(obj.register_from_user);
+      }
+      if (obj.register_from_domain) {
+        setFromDomain(obj.register_from_domain);
+      }
+      if (obj.register_public_ip_in_contact) {
+        setRegPublicIpInContact(obj.register_public_ip_in_contact);
+      }
 
       if (
         obj.requires_register ||
         obj.register_username ||
         obj.register_password ||
-        obj.register_sip_realm
+        obj.register_sip_realm ||
+        obj.register_from_user ||
+        obj.register_from_domain ||
+        obj.register_public_ip_in_contact
       ) {
         setInitialRegister(true);
       } else {
@@ -456,6 +471,11 @@ export const CarrierForm = ({
         register_username: sipUser.trim() || null,
         register_password: sipPass.trim() || null,
         register_sip_realm: sipRealm.trim() || null,
+        register_from_user: sipRegister && fromUser ? fromUser.trim() : null,
+        register_from_domain:
+          sipRegister && fromDomain ? fromDomain.trim() : null,
+        register_public_ip_in_contact:
+          sipRegister && regPublicIpInContact ? true : false,
         tech_prefix: prefix.trim() || null,
         diversion: diversion.trim() || null,
         is_active: isActive,
@@ -675,6 +695,9 @@ export const CarrierForm = ({
                     setSipPass("");
                     setSipRealm("");
                     setSipRegister(false);
+                    setFromUser("");
+                    setFromDomain("");
+                    setRegPublicIpInContact(false);
                   }
                 }}
               >
@@ -736,6 +759,36 @@ export const CarrierForm = ({
                       placeholder="SIP realm for registration"
                       required={sipRegister}
                       onChange={(e) => setSipRealm(e.target.value)}
+                    />
+                    <label htmlFor="fromUser">SIP From User</label>
+                    <input
+                      id="from_user"
+                      name="from_user"
+                      type="text"
+                      value={fromUser}
+                      placeholder="Optional: specify user part of SIP From header"
+                      onChange={(e) => setFromUser(e.target.value)}
+                    />
+                    <label htmlFor="sipFromDomain">SIP From Domain</label>
+                    <input
+                      id="from_domain"
+                      name="from_domain"
+                      type="text"
+                      value={fromDomain}
+                      placeholder="Optional: specify host part of SIP From header"
+                      onChange={(e) => setFromDomain(e.target.value)}
+                    />
+                    <label htmlFor="regPublicIpInContact">
+                      Use Public IP in Contact
+                    </label>
+                    <input
+                      id="reg_public_ip_in_contact"
+                      name="reg_public_ip_in_contact"
+                      type="checkbox"
+                      checked={regPublicIpInContact}
+                      onChange={(e) =>
+                        setRegPublicIpInContact(e.target.checked)
+                      }
                     />
                   </>
                 )}

--- a/src/containers/internal/views/carriers/form.tsx
+++ b/src/containers/internal/views/carriers/form.tsx
@@ -778,18 +778,18 @@ export const CarrierForm = ({
                       placeholder="Optional: specify host part of SIP From header"
                       onChange={(e) => setFromDomain(e.target.value)}
                     />
-                    <label htmlFor="regPublicIpInContact">
-                      Use Public IP in Contact
+                    <label htmlFor="regPublicIpInContact" className="chk">
+                      <input
+                        id="reg_public_ip_in_contact"
+                        name="reg_public_ip_in_contact"
+                        type="checkbox"
+                        checked={regPublicIpInContact}
+                        onChange={(e) =>
+                          setRegPublicIpInContact(e.target.checked)
+                        }
+                      />
+                      <div>Use Public IP in Contact</div>
                     </label>
-                    <input
-                      id="reg_public_ip_in_contact"
-                      name="reg_public_ip_in_contact"
-                      type="checkbox"
-                      checked={regPublicIpInContact}
-                      onChange={(e) =>
-                        setRegPublicIpInContact(e.target.checked)
-                      }
-                    />
                   </>
                 )}
               </Checkzone>

--- a/src/containers/internal/views/carriers/form.tsx
+++ b/src/containers/internal/views/carriers/form.tsx
@@ -474,8 +474,7 @@ export const CarrierForm = ({
         register_from_user: sipRegister && fromUser ? fromUser.trim() : null,
         register_from_domain:
           sipRegister && fromDomain ? fromDomain.trim() : null,
-        register_public_ip_in_contact:
-          sipRegister && regPublicIpInContact ? true : false,
+        register_public_ip_in_contact: sipRegister && regPublicIpInContact,
         tech_prefix: prefix.trim() || null,
         diversion: diversion.trim() || null,
         is_active: isActive,
@@ -760,7 +759,7 @@ export const CarrierForm = ({
                       required={sipRegister}
                       onChange={(e) => setSipRealm(e.target.value)}
                     />
-                    <label htmlFor="fromUser">SIP From User</label>
+                    <label htmlFor="from_user">SIP From User</label>
                     <input
                       id="from_user"
                       name="from_user"
@@ -769,7 +768,7 @@ export const CarrierForm = ({
                       placeholder="Optional: specify user part of SIP From header"
                       onChange={(e) => setFromUser(e.target.value)}
                     />
-                    <label htmlFor="sipFromDomain">SIP From Domain</label>
+                    <label htmlFor="from_domain">SIP From Domain</label>
                     <input
                       id="from_domain"
                       name="from_domain"
@@ -778,7 +777,7 @@ export const CarrierForm = ({
                       placeholder="Optional: specify host part of SIP From header"
                       onChange={(e) => setFromDomain(e.target.value)}
                     />
-                    <label htmlFor="regPublicIpInContact" className="chk">
+                    <label htmlFor="reg_public_ip_in_contact" className="chk">
                       <input
                         id="reg_public_ip_in_contact"
                         name="reg_public_ip_in_contact"


### PR DESCRIPTION
This PR adds the new inputs to the Carrier form on the main branch. 
Inputs added:
- register_from_user 
- register_from_domain 
- register_public_ip_in_contact 

![image](https://user-images.githubusercontent.com/63853378/197396081-a5ad7328-c523-4652-839d-a171ca263c4c.png)