### PR TITLE
Prefill predefined carrier gateways in a form

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -194,7 +194,10 @@ export const getFetch = <Type>(url: string) => {
   });
 };
 
-export const postFetch = <Type, Payload>(url: string, payload: Payload) => {
+export const postFetch = <Type, Payload>(
+  url: string,
+  payload: Payload | undefined
+) => {
   return fetchTransport<Type>(url, {
     method: "POST",
     ...(payload && { body: JSON.stringify(payload) }),
@@ -286,12 +289,11 @@ export const postCarrier = (sid: string, payload: Partial<Carrier>) => {
 
 export const postPredefinedCarrierTemplate = (
   currentServiceProviderSid: string,
-  predefinedCarrierSid: string,
-  payload: void
+  predefinedCarrierSid: string
 ) => {
-  return postFetch<SidResponse, void>(
+  return postFetch<SidResponse, undefined>(
     `${API_BASE_URL}/ServiceProviders/${currentServiceProviderSid}/PredefinedCarriers/${predefinedCarrierSid}`,
-    payload
+    undefined
   );
 };
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -194,9 +194,9 @@ export const getFetch = <Type>(url: string) => {
   });
 };
 
-export const postFetch = <Type, Payload>(
+export const postFetch = <Type, Payload = undefined>(
   url: string,
-  payload: Payload | undefined
+  payload?: Payload
 ) => {
   return fetchTransport<Type>(url, {
     method: "POST",
@@ -291,9 +291,8 @@ export const postPredefinedCarrierTemplate = (
   currentServiceProviderSid: string,
   predefinedCarrierSid: string
 ) => {
-  return postFetch<SidResponse, undefined>(
-    `${API_BASE_URL}/ServiceProviders/${currentServiceProviderSid}/PredefinedCarriers/${predefinedCarrierSid}`,
-    undefined
+  return postFetch<SidResponse>(
+    `${API_BASE_URL}/ServiceProviders/${currentServiceProviderSid}/PredefinedCarriers/${predefinedCarrierSid}`
   );
 };
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -197,7 +197,7 @@ export const getFetch = <Type>(url: string) => {
 export const postFetch = <Type, Payload>(url: string, payload: Payload) => {
   return fetchTransport<Type>(url, {
     method: "POST",
-    body: JSON.stringify(payload),
+    body: payload ? JSON.stringify(payload) : null,
     headers: getAuthHeaders(),
   });
 };
@@ -285,10 +285,14 @@ export const postCarrier = (sid: string, payload: Partial<Carrier>) => {
 };
 
 export const postPredefinedCarrierTemplate = (
-  apiPath: string,
+  currentServiceProviderSid: string,
+  predefinedCarrierSid: string,
   payload: void
 ) => {
-  return postFetch<SidResponse, void>(`${API_BASE_URL}/${apiPath}`, payload);
+  return postFetch<SidResponse, void>(
+    `${API_BASE_URL}/ServiceProviders/${currentServiceProviderSid}/PredefinedCarriers/${predefinedCarrierSid}`,
+    payload
+  );
 };
 
 export const postSipGateway = (payload: Partial<SipGateway>) => {
@@ -539,6 +543,7 @@ export const useApiData: UseApiData = <Type>(apiPath: string) => {
 
   useEffect(() => {
     let ignore = false;
+
     getFetch<Type>(`${API_BASE_URL}/${apiPath}`)
       .then(({ json }) => {
         if (!ignore) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -197,7 +197,7 @@ export const getFetch = <Type>(url: string) => {
 export const postFetch = <Type, Payload>(url: string, payload: Payload) => {
   return fetchTransport<Type>(url, {
     method: "POST",
-    body: payload ? JSON.stringify(payload) : null,
+    ...(payload && { body: JSON.stringify(payload) }),
     headers: getAuthHeaders(),
   });
 };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -284,6 +284,13 @@ export const postCarrier = (sid: string, payload: Partial<Carrier>) => {
   );
 };
 
+export const postPredefinedCarrierTemplate = (
+  apiPath: string,
+  payload: void
+) => {
+  return postFetch<SidResponse, void>(`${API_BASE_URL}/${apiPath}`, payload);
+};
+
 export const postSipGateway = (payload: Partial<SipGateway>) => {
   return postFetch<SidResponse, Partial<SipGateway>>(API_SIP_GATEWAY, payload);
 };
@@ -532,7 +539,6 @@ export const useApiData: UseApiData = <Type>(apiPath: string) => {
 
   useEffect(() => {
     let ignore = false;
-
     getFetch<Type>(`${API_BASE_URL}/${apiPath}`)
       .then(({ json }) => {
         if (!ignore) {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -299,6 +299,7 @@ export interface Carrier {
 
 export interface PredefinedCarrier extends Carrier {
   requires_static_ip: boolean;
+  predefined_carrier_sid: string;
 }
 
 export interface Gateway {

--- a/src/containers/internal/views/carriers/form.tsx
+++ b/src/containers/internal/views/carriers/form.tsx
@@ -13,6 +13,7 @@ import {
   putSmppGateway,
   useApiData,
   useServiceProviderData,
+  postPredefinedCarrierTemplate,
 } from "src/api";
 import {
   DEFAULT_SIP_GATEWAY,
@@ -523,23 +524,25 @@ export const CarrierForm = ({
 
   useEffect(() => {
     if (predefinedName && hasLength(predefinedCarriers)) {
-      setCarrierStates(
-        predefinedCarriers.filter((a) => a.name === predefinedName)[0]
-      );
-
       const currentServiceProviderSid =
         currentServiceProvider?.service_provider_sid;
-      const predefinedCarrierSid = predefinedCarriers?.filter(
-        (a) => a.name === predefinedName
-      )[0].predefined_carrier_sid;
-      const [predefinedSipGateways] = useApiData<SipGateway[]>(
+      const predefinedCarrierSid =
+        predefinedName.length !== 0
+          ? predefinedCarriers?.filter((a) => a.name === predefinedName)[0]
+              .predefined_carrier_sid
+          : null;
+
+      postPredefinedCarrierTemplate(
         `ServiceProviders/${currentServiceProviderSid}/PredefinedCarriers/${predefinedCarrierSid}`
-      );
-      if (predefinedSipGateways) {
-        setSipGateways(predefinedSipGateways);
-      }
+      )
+        .then(({ json }) => {
+          navigate(`${ROUTE_INTERNAL_CARRIERS}/${json.sid}/edit`);
+        })
+        .catch((error) => {
+          toastError(error.msg);
+        });
     }
-  }, [predefinedName, sipGateways]);
+  }, [predefinedName]);
 
   useEffect(() => {
     if (carrier && carrier.data) {

--- a/src/containers/internal/views/carriers/form.tsx
+++ b/src/containers/internal/views/carriers/form.tsx
@@ -524,10 +524,9 @@ export const CarrierForm = ({
 
   useEffect(() => {
     if (predefinedName && hasLength(predefinedCarriers)) {
-      const predefinedCarrierSid = predefinedName
-        ? predefinedCarriers.find((a) => a.name === predefinedName)
-            ?.predefined_carrier_sid
-        : null;
+      const predefinedCarrierSid = predefinedCarriers.find(
+        (a) => a.name === predefinedName
+      )?.predefined_carrier_sid;
 
       if (currentServiceProvider && predefinedCarrierSid) {
         postPredefinedCarrierTemplate(

--- a/src/containers/internal/views/carriers/form.tsx
+++ b/src/containers/internal/views/carriers/form.tsx
@@ -526,8 +526,20 @@ export const CarrierForm = ({
       setCarrierStates(
         predefinedCarriers.filter((a) => a.name === predefinedName)[0]
       );
+
+      const currentServiceProviderSid =
+        currentServiceProvider?.service_provider_sid;
+      const predefinedCarrierSid = predefinedCarriers?.filter(
+        (a) => a.name === predefinedName
+      )[0].predefined_carrier_sid;
+      const [predefinedSipGateways] = useApiData<SipGateway[]>(
+        `ServiceProviders/${currentServiceProviderSid}/PredefinedCarriers/${predefinedCarrierSid}`
+      );
+      if (predefinedSipGateways) {
+        setSipGateways(predefinedSipGateways);
+      }
     }
-  }, [predefinedName]);
+  }, [predefinedName, sipGateways]);
 
   useEffect(() => {
     if (carrier && carrier.data) {

--- a/src/containers/internal/views/carriers/form.tsx
+++ b/src/containers/internal/views/carriers/form.tsx
@@ -524,23 +524,23 @@ export const CarrierForm = ({
 
   useEffect(() => {
     if (predefinedName && hasLength(predefinedCarriers)) {
-      const currentServiceProviderSid =
-        currentServiceProvider?.service_provider_sid;
-      const predefinedCarrierSid =
-        predefinedName.length !== 0
-          ? predefinedCarriers?.filter((a) => a.name === predefinedName)[0]
-              .predefined_carrier_sid
-          : null;
+      const predefinedCarrierSid = predefinedName
+        ? predefinedCarriers.find((a) => a.name === predefinedName)
+            ?.predefined_carrier_sid
+        : null;
 
-      postPredefinedCarrierTemplate(
-        `ServiceProviders/${currentServiceProviderSid}/PredefinedCarriers/${predefinedCarrierSid}`
-      )
-        .then(({ json }) => {
-          navigate(`${ROUTE_INTERNAL_CARRIERS}/${json.sid}/edit`);
-        })
-        .catch((error) => {
-          toastError(error.msg);
-        });
+      if (currentServiceProvider && predefinedCarrierSid) {
+        postPredefinedCarrierTemplate(
+          currentServiceProvider.service_provider_sid,
+          predefinedCarrierSid
+        )
+          .then(({ json }) => {
+            navigate(`${ROUTE_INTERNAL_CARRIERS}/${json.sid}/edit`);
+          })
+          .catch((error) => {
+            toastError(error.msg);
+          });
+      }
     }
   }, [predefinedName]);
 


### PR DESCRIPTION
Added a post request to get the sid for the template and then navigate to the template.
This way we navigate to a template created and to `/internal/carriers/<template_sid>/edit`