### PR TITLE
fix state for tts_api_key and voice typo

### DIFF
--- a/src/containers/internal/views/speech-services/form.tsx
+++ b/src/containers/internal/views/speech-services/form.tsx
@@ -227,7 +227,7 @@ export const SpeechServiceForm = ({ credential }: SpeechServiceFormProps) => {
       }
 
       if (credential.data.tts_api_key) {
-        setSttApiKey(credential.data.tts_api_key);
+        setTtsApiKey(credential.data.tts_api_key);
       }
 
       if (credential.data.tts_region) {

--- a/src/vendor/speech-synthesis/ibm-speech-synthesis-lang.ts
+++ b/src/vendor/speech-synthesis/ibm-speech-synthesis-lang.ts
@@ -86,7 +86,7 @@ export const languages: VoiceLanguage[] = [
       { value: "en-GB_JamesV3Voice", name: "James (Male)" },
       { value: "en-GB_KateVoice", name: "Kate (Female)" },
       { value: "en-GB_KateV3Voice", name: "Kate 2 (Female)" },
-      { value: "en-GB_CharlotteV3Voice", name: "Kate (Female)" },
+      { value: "en-GB_CharlotteV3Voice", name: "Charlotte (Female)" },
     ],
   },
   {


### PR DESCRIPTION
Fix issue with showing tts api key:
![image](https://user-images.githubusercontent.com/63853378/207157166-5eff0a74-7f9a-4f9a-b6b9-93c2dde070bb.png)

Fix voice List having 3 Kates for en-GB.