### PR TITLE
Scope optional limits

### DIFF
--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -152,17 +152,17 @@ export const LIMITS: LimitField[] = [
   },
 ];
 
-export const LIMIT_MINS = "minutes";
-export const LIMIT_SESS = "sessions";
+export const LIMIT_MIN = "minute";
+export const LIMIT_SESS = "session";
 
 export const LIMIT_UNITS: LimitUnitOption[] = [
   {
-    name: "Sessions",
+    name: "Session",
     value: LIMIT_SESS,
   },
   {
-    name: "Minutes",
-    value: LIMIT_MINS,
+    name: "Minute",
+    value: LIMIT_MIN,
   },
 ];
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -327,6 +327,7 @@ export const postServiceProviderLimit = (
   sid: string,
   payload: Partial<Limit>
 ) => {
+  console.log(payload);
   return postFetch<SidResponse, Partial<Limit>>(
     `${API_SERVICE_PROVIDERS}/${sid}/Limits`,
     payload

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -16,7 +16,7 @@ export type LimitCategories =
   | "voice_call_minutes"
   | "voice_call_session_license";
 
-export type LimitUnit = "Sessions" | "Minutes";
+export type LimitUnit = "Session" | "Minute";
 
 export interface LimitUnitOption {
   name: LimitUnit;

--- a/src/components/forms/local-limits.tsx
+++ b/src/components/forms/local-limits.tsx
@@ -101,6 +101,7 @@ export const LocalLimits = ({
         return (
           user && (
             <ScopedAccess
+              key={category}
               user={user}
               scope={
                 (import.meta.env.VITE_APP_ENABLE_ACCOUNT_LIMITS_ALL &&

--- a/src/components/forms/local-limits.tsx
+++ b/src/components/forms/local-limits.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 
 import {
   LIMITS,
-  LIMIT_MINS,
+  LIMIT_MIN,
   LIMIT_SESS,
   LIMIT_UNITS,
   USER_ADMIN,
@@ -51,21 +51,21 @@ export const LocalLimits = ({
   const filteredLimits = import.meta.env.VITE_APP_ENABLE_ACCOUNT_LIMITS_ALL
     ? LIMITS.filter((limit) =>
         unit === LIMIT_SESS
-          ? !limit.category.includes(LIMIT_MINS)
-          : limit.category.includes(LIMIT_MINS)
+          ? !limit.category.includes(LIMIT_MIN)
+          : limit.category.includes(LIMIT_MIN)
       )
     : LIMITS.filter(
         (limit) =>
           !limit.category.includes("license") &&
-          !limit.category.includes(LIMIT_MINS)
+          !limit.category.includes(LIMIT_MIN)
       );
 
   useEffect(() => {
     if (hasLength(data)) {
       setLocalLimits(data);
       setUnit(() => {
-        return data.find((l) => l.category.includes(LIMIT_MINS))
-          ? LIMIT_MINS
+        return data.find((l) => l.category.includes(LIMIT_MIN))
+          ? LIMIT_MIN
           : LIMIT_SESS;
       });
     } else {
@@ -77,14 +77,23 @@ export const LocalLimits = ({
     <>
       {import.meta.env.VITE_APP_ENABLE_ACCOUNT_LIMITS_ALL && (
         <>
-          <label htmlFor="units">Units</label>
+          <label htmlFor="units">Unit</label>
           <Selector
             id="units"
             name="units"
             value={unit}
             options={LIMIT_UNITS}
-            onChange={(e) => setUnit(e.target.value as Lowercase<LimitUnit>)}
             disabled={user && user.scope !== USER_ADMIN}
+            onChange={(e) => {
+              setUnit(e.target.value as Lowercase<LimitUnit>);
+              if (e.target.value !== unit) {
+                localLimits.forEach((l) => {
+                  if (l.category.includes(unit)) {
+                    l.quantity = "";
+                  }
+                });
+              }
+            }}
           />
         </>
       )}

--- a/src/containers/internal/views/settings/service-provider-settings.tsx
+++ b/src/containers/internal/views/settings/service-provider-settings.tsx
@@ -125,7 +125,7 @@ export const ServiceProviderSettings = ({
         setInitialCheck(false);
       }
     }
-  }, [currentServiceProvider]);
+  }, [currentServiceProvider, limits]);
 
   return (
     <>
@@ -143,9 +143,11 @@ export const ServiceProviderSettings = ({
           onChange={(e) => setName(e.target.value)}
         />
       </fieldset>
-      <fieldset>
-        <LocalLimits data={limits} limits={[localLimits, setLocalLimits]} />
-      </fieldset>
+      {!import.meta.env.VITE_APP_ENABLE_ACCOUNT_LIMITS_ALL && (
+        <fieldset>
+          <LocalLimits data={limits} limits={[localLimits, setLocalLimits]} />
+        </fieldset>
+      )}
       <fieldset>
         <Checkzone
           name="teams"


### PR DESCRIPTION
@davehorton @kitajchuk This was the code that was lost somehow during the scoping. 
As agreed, we wanted the new call limits under the env VITE_APP_ENABLE_ACCOUNT_LIMITS_ALL to be disabled for non-admin users, and the MAX limits hidden completely.

Account User view with env VITE_APP_ENABLE_ACCOUNT_LIMITS_ALL
![image](https://user-images.githubusercontent.com/63853378/210963558-0a12bda2-8154-4f8a-9083-289cbba3376d.png)

Admin user view env VITE_APP_ENABLE_ACCOUNT_LIMITS_ALL
![image](https://user-images.githubusercontent.com/63853378/210963389-0350a758-93cd-4bee-8861-6e479c5fc6a0.png)


There is still a question on where we should handle the deletion of the limits set the first time that are in contradiction with the new limits set (e.g. we set session limits, then we decide to change to minutes limits the session limits are not deleted all limits we send more limits and all exist in the backend - so the old ones should be deleted). @davehorton @kitajchuk what do you think should we do this in the frontend?