### PR TITLE
Date fix for alerts and recent calls

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -530,19 +530,19 @@ export const getRecentCalls = (sid: string, query: Partial<CallQuery>) => {
   );
 };
 
-export const getRecentCall = (sid: string, callSid: string) => {
+export const getRecentCall = (sid: string, sipCallId: string) => {
   return getFetch<TotalResponse>(
     import.meta.env.DEV
-      ? `${DEV_BASE_URL}/Accounts/${sid}/RecentCalls/${callSid}`
-      : `${API_ACCOUNTS}/${sid}/RecentCalls/${callSid}`
+      ? `${DEV_BASE_URL}/Accounts/${sid}/RecentCalls/${sipCallId}`
+      : `${API_ACCOUNTS}/${sid}/RecentCalls/${sipCallId}`
   );
 };
 
-export const getPcap = (sid: string, callSid: string) => {
+export const getPcap = (sid: string, sipCallId: string) => {
   return getBlob(
     import.meta.env.DEV
-      ? `${DEV_BASE_URL}/Accounts/${sid}/RecentCalls/${callSid}/pcap`
-      : `${API_ACCOUNTS}/${sid}/RecentCalls/${callSid}/pcap`
+      ? `${DEV_BASE_URL}/Accounts/${sid}/RecentCalls/${sipCallId}/pcap`
+      : `${API_ACCOUNTS}/${sid}/RecentCalls/${sipCallId}/pcap`
   );
 };
 

--- a/src/components/forms/local-limits.tsx
+++ b/src/components/forms/local-limits.tsx
@@ -110,7 +110,7 @@ export const LocalLimits = ({
                 Scope.account
               }
             >
-              <React.Fragment key={category}>
+              <React.Fragment>
                 <label htmlFor={category}>{label}</label>
                 <input
                   ref={(el: HTMLInputElement) => {

--- a/src/containers/internal/views/alerts/index.tsx
+++ b/src/containers/internal/views/alerts/index.tsx
@@ -101,9 +101,7 @@ export const Alerts = () => {
                 <div className="item__info">
                   <div className="item__title txt--jam">
                     <strong>
-                      {dayjs
-                        .unix(alert.time / 1000)
-                        .format("YYYY MM.DD hh:mm a")}
+                      {dayjs(alert.time).format("YYYY MM.DD hh:mm a")}
                     </strong>
                   </div>
                   <div className="item__meta">

--- a/src/containers/internal/views/recent-calls/details.tsx
+++ b/src/containers/internal/views/recent-calls/details.tsx
@@ -28,9 +28,7 @@ export const DetailsItem = ({ call }: DetailsItemProps) => {
           <div className="item__info">
             <div className="item__title">
               <strong>
-                {dayjs
-                  .unix(call.attempted_at / 1000)
-                  .format("YYYY MM.DD hh:mm a")}
+                {dayjs(call.attempted_at).format("YYYY MM.DD hh:mm a")}
               </strong>
               <span className="i txt--dark">
                 {call.direction === "inbound" ? (

--- a/src/containers/internal/views/recent-calls/details.tsx
+++ b/src/containers/internal/views/recent-calls/details.tsx
@@ -60,7 +60,11 @@ export const DetailsItem = ({ call }: DetailsItemProps) => {
             {Object.keys(call).map((key) => (
               <React.Fragment key={key}>
                 <div>{key}:</div>
-                <div>{call[key as keyof typeof call].toString()}</div>
+                <div>
+                  {call[key as keyof typeof call]
+                    ? call[key as keyof typeof call].toString()
+                    : "null"}
+                </div>
               </React.Fragment>
             ))}
           </div>

--- a/src/containers/internal/views/recent-calls/pcap.tsx
+++ b/src/containers/internal/views/recent-calls/pcap.tsx
@@ -13,10 +13,10 @@ export const PcapButton = ({ call }: PcapButtonProps) => {
   const [pcap, setPcap] = useState<Pcap>();
 
   useEffect(() => {
-    getRecentCall(call.account_sid, call.call_sid)
+    getRecentCall(call.account_sid, call.sip_callid)
       .then(({ json }) => {
         if (json.total > 0) {
-          getPcap(call.account_sid, call.call_sid)
+          getPcap(call.account_sid, call.sip_callid)
             .then(({ blob }) => {
               if (blob) {
                 setPcap({


### PR DESCRIPTION
"Invalid date" was displayed instead of a title for Alerts and recent calls

![image](https://user-images.githubusercontent.com/63853378/212324578-21e2d532-3b54-4fa2-b0b5-0303555785be.png)

The date format received:

{
  "call": {
    "attempted_at": "2022-12-28T18:43:53.874Z",
    "account_sid": "xxx",
    "answered": true,
    "answered_at": "2022-12-28T18:43:56.841Z",
    "application_sid": "xxx",
    "call_sid": "xxx",
    "direction": "inbound",
    "duration": 17,
    "from": "+xxxxxxx",
    "host": "undefined",
    "remote_host": "54.172.60.3",
    "service_provider_sid": "2708b1b3-2736-40ea-b502-c53d8396247f",
    "sip_callid": "xxxx@0.0.0.0",
    "sip_status": 200,
    "terminated_at": "2022-12-28T18:44:14.226Z",
    "termination_reason": "called party hungup",
    "to": "+15082069511",
    "trace_id": "xxx",
    "trunk": "Twilio"
  }
}