### PR TITLE
Fix issue where is_active user & force_change cannot be deactivated

### DIFF
--- a/src/containers/internal/views/settings/index.tsx
+++ b/src/containers/internal/views/settings/index.tsx
@@ -9,7 +9,7 @@ import { ScopedAccess } from "src/components/scoped-access";
 import type { ServiceProvider } from "src/api/types";
 import { Section } from "src/components";
 
-import { USER_ADMIN } from "src/api/constants";
+import { USER_ACCOUNT, USER_ADMIN } from "src/api/constants";
 import { MSG_REQUIRED_FIELDS } from "src/constants";
 import { useSelectState } from "src/store";
 import { Scope } from "src/store/types";
@@ -56,16 +56,17 @@ export const Settings = ({ currentServiceProvider }: SettingsProps) => {
         </form>
       </Section>
 
-      {currentServiceProvider && activeTab === "serviceProvider" && (
-        <ApiKeys
-          key={currentServiceProvider.service_provider_sid}
-          path={`ServiceProviders/${currentServiceProvider.service_provider_sid}/ApiKeys`}
-          post={{
-            service_provider_sid: currentServiceProvider.service_provider_sid,
-          }}
-          label="Service provider"
-        />
-      )}
+      {currentServiceProvider &&
+        (activeTab === "serviceProvider" || user?.scope !== USER_ACCOUNT) && (
+          <ApiKeys
+            key={currentServiceProvider.service_provider_sid}
+            path={`ServiceProviders/${currentServiceProvider.service_provider_sid}/ApiKeys`}
+            post={{
+              service_provider_sid: currentServiceProvider.service_provider_sid,
+            }}
+            label="Service provider"
+          />
+        )}
     </>
   );
 };

--- a/src/containers/internal/views/users/form.tsx
+++ b/src/containers/internal/views/users/form.tsx
@@ -138,11 +138,11 @@ export const UserForm = ({ user }: UserFormProps) => {
       }
 
       putUser(user.data.user_sid, {
-        name: name || user.data.name,
-        email: email || user.data.email,
+        name: name,
+        email: email,
         initial_password: initialPassword || null,
-        force_change: forceChange || !!user.data.force_change,
-        is_active: isActive || !!user.data.is_active,
+        force_change: forceChange,
+        is_active: isActive,
         service_provider_sid:
           scope === USER_ADMIN && currentUser?.scope === USER_ADMIN
             ? null


### PR DESCRIPTION
Related PR in jambonz-api-server: https://github.com/jambonz/jambonz-api-server/pull/95

We allow falsy values to be sent and updated. Before api was updating only a truthy value.