### PR TITLE
Always attach service_provider_sid to a carrier

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 VITE_API_BASE_URL=http://127.0.0.1:3000/v1
-VITE_DEV_BASE_URL=http://127.0.0.1:3002/api
+VITE_DEV_BASE_URL=http://127.0.0.1:3000/v1
 
 ## enables choosing units and lisenced account call limits
 # VITE_APP_ENABLE_ACCOUNT_LIMITS_ALL=true

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -327,7 +327,6 @@ export const postServiceProviderLimit = (
   sid: string,
   payload: Partial<Limit>
 ) => {
-  console.log(payload);
   return postFetch<SidResponse, Partial<Limit>>(
     `${API_SERVICE_PROVIDERS}/${sid}/Limits`,
     payload

--- a/src/containers/internal/views/carriers/form.tsx
+++ b/src/containers/internal/views/carriers/form.tsx
@@ -481,6 +481,7 @@ export const CarrierForm = ({
         name: carrierName.trim(),
         e164_leading_plus: e164,
         application_sid: applicationSid || null,
+        service_provider_sid: currentServiceProvider.service_provider_sid,
         account_sid: accountSid || null,
         requires_register: sipRegister,
         register_username: sipUser.trim() || null,


### PR DESCRIPTION
Service provider sid was not attached when an account level carrier was created, thus Phone number fetch of carriers did not contain account-related carriers.

This now allows the Account user to create account level Carrier and then add a Phone number.

I still think that we should restrict /SP API to return only relevant account carriers. Now if there are more accounts all will be fetched.

Related PR was created to limit /SP API to scope for both VoipCarriers and Speech Creds
https://github.com/jambonz/jambonz-api-server/pull/96