### PR TITLE
Spinner spinning forever issue

### DIFF
--- a/src/containers/internal/views/alerts/index.tsx
+++ b/src/containers/internal/views/alerts/index.tsx
@@ -93,7 +93,7 @@ export const Alerts = () => {
       </section>
       <Section {...(hasLength(alerts) && { slim: true })}>
         <div className="list">
-          {!hasValue(alerts) ? (
+          {!hasValue(alerts) && hasLength(accounts) ? (
             <Spinner />
           ) : hasLength(alerts) ? (
             alerts.map((alert) => (

--- a/src/containers/internal/views/applications/index.tsx
+++ b/src/containers/internal/views/applications/index.tsx
@@ -106,7 +106,7 @@ export const Applications = () => {
       </section>
       <Section {...(hasLength(filteredApplications) && { slim: true })}>
         <div className="list">
-          {!hasValue(applications) ? (
+          {!hasValue(applications) && hasLength(accounts) ? (
             <Spinner />
           ) : hasLength(filteredApplications) ? (
             filteredApplications.map((application) => {

--- a/src/containers/internal/views/carriers/index.tsx
+++ b/src/containers/internal/views/carriers/index.tsx
@@ -146,7 +146,7 @@ export const Carriers = () => {
       </section>
       <Section {...(hasLength(filteredCarriers) && { slim: true })}>
         <div className="list">
-          {!hasValue(carriers) ? (
+          {!hasValue(carriers) && !hasLength(accounts) ? (
             <Spinner />
           ) : hasLength(filteredCarriers) ? (
             filteredCarriers.map((carrier) => (

--- a/src/containers/internal/views/carriers/index.tsx
+++ b/src/containers/internal/views/carriers/index.tsx
@@ -146,7 +146,7 @@ export const Carriers = () => {
       </section>
       <Section {...(hasLength(filteredCarriers) && { slim: true })}>
         <div className="list">
-          {!hasValue(carriers) && !hasLength(accounts) ? (
+          {!hasValue(carriers) && hasLength(accounts) ? (
             <Spinner />
           ) : hasLength(filteredCarriers) ? (
             filteredCarriers.map((carrier) => (

--- a/src/containers/internal/views/recent-calls/index.tsx
+++ b/src/containers/internal/views/recent-calls/index.tsx
@@ -122,7 +122,7 @@ export const RecentCalls = () => {
       </section>
       <Section {...(hasLength(calls) && { slim: true })}>
         <div className="list">
-          {!hasValue(calls) ? (
+          {!hasValue(calls) && hasLength(accounts) ? (
             <Spinner />
           ) : hasLength(calls) ? (
             calls.map((call) => <DetailsItem key={call.call_sid} call={call} />)

--- a/src/containers/internal/views/speech-services/index.tsx
+++ b/src/containers/internal/views/speech-services/index.tsx
@@ -108,7 +108,7 @@ export const SpeechServices = () => {
       </section>
       <Section {...(hasLength(filteredCredentials) && { slim: true })}>
         <div className="list">
-          {!hasValue(filteredCredentials) ? (
+          {!hasValue(filteredCredentials) && hasLength(accounts) ? (
             <Spinner />
           ) : hasLength(filteredCredentials) ? (
             filteredCredentials.map((credential) => {

--- a/src/containers/internal/views/users/index.tsx
+++ b/src/containers/internal/views/users/index.tsx
@@ -113,7 +113,7 @@ export const Users = () => {
             <div>Scope</div>
             <div>&nbsp;</div>
           </div>
-          {!hasValue(users) ? (
+          {!hasValue(users) && hasLength(accounts) ? (
             <Spinner />
           ) : hasLength(filteredUsers) ? (
             filteredUsers.map((user) => {


### PR DESCRIPTION
The Spinner issue appeared everywhere where "accounts" array length was needed. So to reproduce this create a new SP and do not create any accounts, then go to Recent Calls, Alerts, Applications where !hasValue(aplications) will be true if accounts array is empty. 

So now this PR is adding a check that also checks for the length of the Accounts. This fixes the issue of the spinner