### PR TITLE
Combine account user lists for carriers and speech

### DIFF
--- a/src/containers/internal/views/applications/edit.tsx
+++ b/src/containers/internal/views/applications/edit.tsx
@@ -34,7 +34,7 @@ export const EditApplication = () => {
 
   return (
     <>
-      <H1 className="h2">Edit Application</H1>
+      <H1 className="h2">Edit application</H1>
       <ApplicationForm application={{ data, refetch, error }} />
     </>
   );

--- a/src/containers/internal/views/carriers/index.tsx
+++ b/src/containers/internal/views/carriers/index.tsx
@@ -47,6 +47,10 @@ export const Carriers = () => {
   const [filter, setFilter] = useState("");
 
   const carriersFiltered = useMemo(() => {
+    if (user?.scope === USER_ACCOUNT) {
+      return carriers;
+    }
+
     return carriers
       ? carriers.filter((carrier) =>
           accountSid
@@ -137,12 +141,14 @@ export const Carriers = () => {
           placeholder="Filter carriers"
           filter={[filter, setFilter]}
         />
-        <AccountFilter
-          account={[accountSid, setAccountSid]}
-          accounts={accounts}
-          label="Used by"
-          defaultOption
-        />
+        <ScopedAccess user={user} scope={Scope.service_provider}>
+          <AccountFilter
+            account={[accountSid, setAccountSid]}
+            accounts={accounts}
+            label="Used by"
+            defaultOption
+          />
+        </ScopedAccess>
       </section>
       <Section {...(hasLength(filteredCarriers) && { slim: true })}>
         <div className="list">
@@ -156,7 +162,9 @@ export const Carriers = () => {
                     <ScopedAccess
                       user={user}
                       scope={
-                        !accountSid ? Scope.service_provider : Scope.account
+                        !carrier.account_sid
+                          ? Scope.service_provider
+                          : Scope.account
                       }
                     >
                       <Link
@@ -168,7 +176,7 @@ export const Carriers = () => {
                         <Icons.ArrowRight />
                       </Link>
                     </ScopedAccess>
-                    {!accountSid && user?.scope === USER_ACCOUNT && (
+                    {!carrier.account_sid && user?.scope === USER_ACCOUNT && (
                       <strong>{carrier.name}</strong>
                     )}
                   </div>
@@ -192,7 +200,11 @@ export const Carriers = () => {
                 </div>
                 <ScopedAccess
                   user={user}
-                  scope={!accountSid ? Scope.service_provider : Scope.account}
+                  scope={
+                    !carrier.account_sid
+                      ? Scope.service_provider
+                      : Scope.account
+                  }
                 >
                   <div className="item__actions">
                     <Link

--- a/src/containers/internal/views/carriers/index.tsx
+++ b/src/containers/internal/views/carriers/index.tsx
@@ -169,7 +169,7 @@ export const Carriers = () => {
                     >
                       <Link
                         to={`${ROUTE_INTERNAL_CARRIERS}/${carrier.voip_carrier_sid}/edit`}
-                        title="Edit Carrier"
+                        title="Edit carrier"
                         className="i"
                       >
                         <strong>{carrier.name}</strong>
@@ -209,7 +209,7 @@ export const Carriers = () => {
                   <div className="item__actions">
                     <Link
                       to={`${ROUTE_INTERNAL_CARRIERS}/${carrier.voip_carrier_sid}/edit`}
-                      title="Edit Carrier"
+                      title="Edit carrier"
                     >
                       <Icons.Edit3 />
                     </Link>

--- a/src/containers/internal/views/speech-services/form.tsx
+++ b/src/containers/internal/views/speech-services/form.tsx
@@ -115,8 +115,7 @@ export const SpeechServiceForm = ({ credential }: SpeechServiceFormProps) => {
       const payload: Partial<SpeechCredential> = {
         vendor,
         account_sid: accountSid || null,
-        service_provider_sid:
-          currentServiceProvider.service_provider_sid || null,
+        service_provider_sid: currentServiceProvider.service_provider_sid,
         use_for_tts: ttsCheck ? 1 : 0,
         use_for_stt: sttCheck ? 1 : 0,
         ...(vendor === VENDOR_AWS && {

--- a/src/containers/internal/views/speech-services/index.tsx
+++ b/src/containers/internal/views/speech-services/index.tsx
@@ -37,6 +37,10 @@ export const SpeechServices = () => {
   const [filter] = useState("");
 
   const credentialsFiltered = useMemo(() => {
+    if (user?.scope === USER_ACCOUNT) {
+      return credentials;
+    }
+
     return credentials
       ? credentials.filter((credential) =>
           accountSid
@@ -99,12 +103,14 @@ export const SpeechServices = () => {
         </Link>
       </section>
       <section className="filters filters--ender">
-        <AccountFilter
-          account={[accountSid, setAccountSid]}
-          accounts={accounts}
-          label="Used by"
-          defaultOption
-        />
+        <ScopedAccess user={user} scope={Scope.service_provider}>
+          <AccountFilter
+            account={[accountSid, setAccountSid]}
+            accounts={accounts}
+            label="Used by"
+            defaultOption
+          />
+        </ScopedAccess>
       </section>
       <Section {...(hasLength(filteredCredentials) && { slim: true })}>
         <div className="list">
@@ -119,7 +125,9 @@ export const SpeechServices = () => {
                       <ScopedAccess
                         user={user}
                         scope={
-                          !accountSid ? Scope.service_provider : Scope.account
+                          !credential.account_sid
+                            ? Scope.service_provider
+                            : Scope.account
                         }
                       >
                         <Link
@@ -131,9 +139,10 @@ export const SpeechServices = () => {
                           <Icons.ArrowRight />
                         </Link>
                       </ScopedAccess>
-                      {!accountSid && user?.scope === USER_ACCOUNT && (
-                        <strong>Vendor: {credential.vendor}</strong>
-                      )}
+                      {!credential.account_sid &&
+                        user?.scope === USER_ACCOUNT && (
+                          <strong>Vendor: {credential.vendor}</strong>
+                        )}
                     </div>
                     <div className="item__meta">
                       <div>
@@ -177,7 +186,11 @@ export const SpeechServices = () => {
                   </div>
                   <ScopedAccess
                     user={user}
-                    scope={!accountSid ? Scope.service_provider : Scope.account}
+                    scope={
+                      !credential.account_sid
+                        ? Scope.service_provider
+                        : Scope.account
+                    }
                   >
                     <div className="item__actions">
                       <Link


### PR DESCRIPTION
This PR combines Carriers and Speech credential lists for account user and disables Filtering according to the account
Account user views for these lists:

![image](https://user-images.githubusercontent.com/63853378/214517739-7aee90d1-0e0c-4173-b029-de0240922b7d.png)

![image](https://user-images.githubusercontent.com/63853378/214517899-6e962620-22c1-4374-afee-5beb56655465.png)

API server small change to have Speech /SP call act the same way as Carriers: https://github.com/jambonz/jambonz-api-server/pull/98  This way the implementation is the same. 