### PR TITLE
Improving naming consistency

### DIFF
--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -106,9 +106,9 @@ export const PER_PAGE_SELECTION = [
 ];
 
 export const USER_SCOPE_SELECTION: SelectorOptions[] = [
-  { name: "All Scopes", value: "all" },
+  { name: "All scopes", value: "all" },
   { name: "Admin", value: "admin" },
-  { name: "Service Provider", value: "service_provider" },
+  { name: "Service provider", value: "service_provider" },
   { name: "Account", value: "account" },
 ];
 

--- a/src/components/forms/passwd/index.tsx
+++ b/src/components/forms/passwd/index.tsx
@@ -31,6 +31,7 @@ export const Passwd = forwardRef<PasswdRef, PasswdProps>(
     return (
       <div className="passwd">
         <input
+          autoComplete={"off"}
           ref={ref}
           type={reveal ? "text" : "password"}
           name={name}

--- a/src/containers/internal/navi/items.ts
+++ b/src/containers/internal/navi/items.ts
@@ -56,7 +56,7 @@ export const naviTop: NaviItem[] = [
     route: () => ROUTE_INTERNAL_APPLICATIONS,
   },
   {
-    label: "Recent Calls",
+    label: "Recent calls",
     icon: Icons.List,
     route: () => ROUTE_INTERNAL_RECENT_CALLS,
   },

--- a/src/containers/internal/views/accounts/delete.tsx
+++ b/src/containers/internal/views/accounts/delete.tsx
@@ -155,7 +155,7 @@ export const DeleteAccount = ({
           {hasLength(inUse.apiKeys) && (
             <InUseItems
               items={inUse.apiKeys}
-              itemsLabel="API Keys"
+              itemsLabel="API keys"
               sidKey="api_key_sid"
               labelKey="token"
             />

--- a/src/containers/internal/views/accounts/form.tsx
+++ b/src/containers/internal/views/accounts/form.tsx
@@ -399,7 +399,7 @@ export const AccountForm = ({ apps, limits, account }: AccountFormProps) => {
                   <Checkzone
                     hidden
                     name={webhook.prefix}
-                    label="Use HTTP Basic Authentication"
+                    label="Use HTTP basic authentication"
                     initialCheck={webhook.initialCheck}
                   >
                     <MS>{MSG_WEBHOOK_FIELDS}</MS>

--- a/src/containers/internal/views/applications/form.tsx
+++ b/src/containers/internal/views/applications/form.tsx
@@ -90,7 +90,7 @@ export const ApplicationForm = ({ application }: ApplicationFormProps) => {
       required: true,
     },
     {
-      label: "Call Status",
+      label: "Call status",
       prefix: "status_webhook",
       stateVal: statusWebhook,
       stateSet: setStatusWebhook,
@@ -287,7 +287,7 @@ export const ApplicationForm = ({ application }: ApplicationFormProps) => {
               <div className="multi">
                 <div className="inp">
                   <label htmlFor={`${webhook.prefix}_url`}>
-                    {webhook.label} Webhook{" "}
+                    {webhook.label} webhook{" "}
                     {webhook.required ? <span>*</span> : ""}
                   </label>
                   <input
@@ -324,7 +324,7 @@ export const ApplicationForm = ({ application }: ApplicationFormProps) => {
               <Checkzone
                 hidden
                 name={webhook.prefix}
-                label="Use HTTP Basic Authentication"
+                label="Use HTTP basic authentication"
                 initialCheck={webhook.initialCheck}
               >
                 <MS>{MSG_WEBHOOK_FIELDS}</MS>
@@ -375,7 +375,7 @@ export const ApplicationForm = ({ application }: ApplicationFormProps) => {
         })}
         {synthesis && (
           <fieldset>
-            <label htmlFor="synthesis_vendor">Speech Synthesis Vendor</label>
+            <label htmlFor="synthesis_vendor">Speech synthesis vendor</label>
             <Selector
               id="synthesis_vendor"
               name="synthesis_vendor"
@@ -471,7 +471,7 @@ export const ApplicationForm = ({ application }: ApplicationFormProps) => {
         )}
         {recognizers && (
           <fieldset>
-            <label htmlFor="recognizer_vendor">Speech Recognizer Vendor</label>
+            <label htmlFor="recognizer_vendor">Speech recognizer vendor</label>
             <Selector
               id="recognizer_vendor"
               name="recognizer_vendor"

--- a/src/containers/internal/views/carriers/form.tsx
+++ b/src/containers/internal/views/carriers/form.tsx
@@ -697,7 +697,7 @@ export const CarrierForm = ({
                   checked={e164}
                   onChange={(e) => setE164(e.target.checked)}
                 />
-                <div>E.164 Syntax</div>
+                <div>E.164 syntax</div>
               </label>
               <MXS>
                 <em>Prepend a leading + on origination attempts.</em>
@@ -711,7 +711,7 @@ export const CarrierForm = ({
                     : accounts
                 }
                 account={[accountSid, setAccountSid]}
-                label="Used By"
+                label="Used by"
                 required={false}
                 defaultOption={checkSelectOptions(user, carrier?.data)}
                 disabled={
@@ -739,7 +739,7 @@ export const CarrierForm = ({
               <Checkzone
                 hidden
                 name="sip_credentials"
-                label="Outbound Authentication"
+                label="Outbound authentication"
                 initialCheck={initialRegister}
                 handleChecked={(e) => {
                   if (!e.target.checked) {
@@ -801,7 +801,7 @@ export const CarrierForm = ({
                       calls.
                     </MS>
                     <label htmlFor="sip_realm">
-                      SIP Realm{sipRegister ? <span>*</span> : ""}
+                      SIP realm{sipRegister ? <span>*</span> : ""}
                     </label>
                     <input
                       id="sip_realm"
@@ -812,7 +812,7 @@ export const CarrierForm = ({
                       required={sipRegister}
                       onChange={(e) => setSipRealm(e.target.value)}
                     />
-                    <label htmlFor="from_user">SIP From User</label>
+                    <label htmlFor="from_user">SIP from user</label>
                     <input
                       id="from_user"
                       name="from_user"
@@ -821,7 +821,7 @@ export const CarrierForm = ({
                       placeholder="Optional: specify user part of SIP From header"
                       onChange={(e) => setFromUser(e.target.value)}
                     />
-                    <label htmlFor="from_domain">SIP From Domain</label>
+                    <label htmlFor="from_domain">SIP from domain</label>
                     <input
                       id="from_domain"
                       name="from_domain"
@@ -840,7 +840,7 @@ export const CarrierForm = ({
                           setRegPublicIpInContact(e.target.checked)
                         }
                       />
-                      <div>Use Public IP in Contact</div>
+                      <div>Use public IP in contact</div>
                     </label>
                   </>
                 )}
@@ -850,7 +850,7 @@ export const CarrierForm = ({
               <Checkzone
                 hidden
                 name="tech_prefix_check"
-                label="Tech Prefix"
+                label="Tech prefix"
                 initialCheck={initialPrefix}
                 handleChecked={(e) => {
                   if (!e.target.checked) {
@@ -904,13 +904,13 @@ export const CarrierForm = ({
             </fieldset>
             <fieldset>
               <label htmlFor="sip_gateways">
-                SIP Gateways<span>*</span>
+                SIP gateways<span>*</span>
               </label>
               <MXS>
                 <em>At least one SIP gateway is required.</em>
               </MXS>
               <label htmlFor="sip_gateways">
-                Network Address / Port / Netmask
+                Network address / Port / Netmask
               </label>
               {sipMessage && <Message message={sipMessage} />}
               {hasLength(sipGateways) &&

--- a/src/containers/internal/views/carriers/form.tsx
+++ b/src/containers/internal/views/carriers/form.tsx
@@ -1097,7 +1097,7 @@ export const CarrierForm = ({
                 }}
               />
               <label htmlFor="outbound_smpp">
-                Carrier SMPP Gateways
+                Carrier SMPP gateways
                 <span>{smppSystemId || smppPass ? "*" : ""}</span>
               </label>
               <MXS>
@@ -1250,7 +1250,7 @@ export const CarrierForm = ({
                 }}
               />
               <label htmlFor="inbound_smpp">
-                Carrier IP Address(es) to whitelist
+                Carrier IP address(es) to whitelist
               </label>
               <MXS>
                 <em>

--- a/src/containers/internal/views/carriers/index.tsx
+++ b/src/containers/internal/views/carriers/index.tsx
@@ -220,7 +220,7 @@ export const Carriers = () => {
       </Section>
       <Section clean>
         <Button small as={Link} to={`${ROUTE_INTERNAL_CARRIERS}/add`}>
-          Add Carrier
+          Add carrier
         </Button>
       </Section>
       {carrier && (

--- a/src/containers/internal/views/phone-numbers/form.tsx
+++ b/src/containers/internal/views/phone-numbers/form.tsx
@@ -159,7 +159,7 @@ export const PhoneNumberForm = ({ phoneNumber }: PhoneNumberFormProps) => {
           </fieldset>
           <fieldset>
             <label htmlFor="sip_trunk">
-              SIP Trunk <span>*</span>
+              Carrier <span>*</span>
             </label>
             <Selector
               id="sip_trunk"

--- a/src/containers/internal/views/recent-calls/index.tsx
+++ b/src/containers/internal/views/recent-calls/index.tsx
@@ -91,7 +91,7 @@ export const RecentCalls = () => {
   return (
     <>
       <section className="mast">
-        <H1 className="h2">Recent Calls</H1>
+        <H1 className="h2">Recent calls</H1>
       </section>
       {/* Setting overflow-x auto for now until we have a better responsive solution... */}
       <section className="filters filters--multi">

--- a/src/containers/internal/views/settings/admin-settings.tsx
+++ b/src/containers/internal/views/settings/admin-settings.tsx
@@ -48,7 +48,7 @@ export const AdminSettings = () => {
   return (
     <>
       <fieldset>
-        <label htmlFor="min_password_length">Min Password Length</label>
+        <label htmlFor="min_password_length">Min password length</label>
         <Selector
           id="min_password_length"
           name="min_password_length"
@@ -64,7 +64,7 @@ export const AdminSettings = () => {
             checked={requireDigit}
             onChange={(e) => setRequireDigit(e.target.checked)}
           />
-          <div>Password Require Digit</div>
+          <div>Password require digit</div>
         </label>
 
         <label htmlFor="require_special_character" className="chk">
@@ -75,7 +75,7 @@ export const AdminSettings = () => {
             checked={requireSpecialCharacter}
             onChange={(e) => setRequireSpecialCharacter(e.target.checked)}
           />
-          <div>Password Require Special Character</div>
+          <div>Password require special character</div>
         </label>
       </fieldset>
       <fieldset>

--- a/src/containers/internal/views/settings/index.tsx
+++ b/src/containers/internal/views/settings/index.tsx
@@ -43,7 +43,7 @@ export const Settings = ({ currentServiceProvider }: SettingsProps) => {
               <Tab id="admin" label="Admin">
                 <AdminSettings />
               </Tab>
-              <Tab id="serviceProvider" label="Service Provider">
+              <Tab id="serviceProvider" label="Service provider">
                 <ServiceProviderSettings />
               </Tab>
             </Tabs>

--- a/src/containers/internal/views/settings/service-provider-settings.tsx
+++ b/src/containers/internal/views/settings/service-provider-settings.tsx
@@ -151,7 +151,7 @@ export const ServiceProviderSettings = ({
       <fieldset>
         <Checkzone
           name="teams"
-          label="Enable MS Teams direct routing"
+          label="Enable MS Teams Direct Routing"
           initialCheck={initialCheck}
           handleChecked={handleChecked}
         >

--- a/src/containers/internal/views/settings/service-provider-settings.tsx
+++ b/src/containers/internal/views/settings/service-provider-settings.tsx
@@ -151,7 +151,7 @@ export const ServiceProviderSettings = ({
       <fieldset>
         <Checkzone
           name="teams"
-          label="Enable MS Teams Direct Routing"
+          label="Enable MS Teams direct routing"
           initialCheck={initialCheck}
           handleChecked={handleChecked}
         >

--- a/src/containers/internal/views/speech-services/form.tsx
+++ b/src/containers/internal/views/speech-services/form.tsx
@@ -404,7 +404,7 @@ export const SpeechServiceForm = ({ credential }: SpeechServiceFormProps) => {
         {vendor === VENDOR_AWS && (
           <fieldset>
             <label htmlFor="aws_access_key">
-              Access Key ID<span>*</span>
+              Access key ID<span>*</span>
             </label>
             <input
               id="aws_access_key"
@@ -417,7 +417,7 @@ export const SpeechServiceForm = ({ credential }: SpeechServiceFormProps) => {
               disabled={credential ? true : false}
             />
             <label htmlFor="aws_secret_key">
-              Secret Access Key<span>*</span>
+              Secret access key<span>*</span>
             </label>
             <Passwd
               id="aws_secret_key"
@@ -439,13 +439,13 @@ export const SpeechServiceForm = ({ credential }: SpeechServiceFormProps) => {
           vendor === VENDOR_DEEPGRAM) && (
           <fieldset>
             <label htmlFor={`${vendor}_apikey`}>
-              API Key<span>*</span>
+              API key<span>*</span>
             </label>
             <Passwd
               id={`${vendor}_apikey`}
               required
               name={`${vendor}_apikey`}
-              placeholder="API Key"
+              placeholder="API key"
               value={apiKey ? getObscuredSecret(apiKey) : apiKey}
               onChange={(e) => setApiKey(e.target.value)}
               disabled={credential ? true : false}
@@ -479,7 +479,7 @@ export const SpeechServiceForm = ({ credential }: SpeechServiceFormProps) => {
           regions[vendor as keyof RegionVendors] && (
             <fieldset>
               <label htmlFor="tts_region">
-                TTS Region {ttsCheck && <span>*</span>}
+                TTS region {ttsCheck && <span>*</span>}
               </label>
               <Selector
                 id="tts_region"
@@ -495,19 +495,19 @@ export const SpeechServiceForm = ({ credential }: SpeechServiceFormProps) => {
                 onChange={(e) => setTtsRegion(e.target.value)}
               />
               <label htmlFor={`${vendor}_tts_apikey`}>
-                TTS API Key {ttsCheck && <span>*</span>}
+                TTS API key {ttsCheck && <span>*</span>}
               </label>
               <Passwd
                 id={`${vendor}_tts_apikey`}
                 required={ttsCheck}
                 name={`${vendor}_tts_apikey`}
-                placeholder="TTS API Key"
+                placeholder="TTS API key"
                 value={ttsApiKey ? getObscuredSecret(ttsApiKey) : ttsApiKey}
                 onChange={(e) => setTtsApiKey(e.target.value)}
                 disabled={credential ? true : false}
               />
               <label htmlFor="stt_region">
-                STT Region {sttCheck && <span>*</span>}
+                STT region {sttCheck && <span>*</span>}
               </label>
               <Selector
                 id="stt_region"
@@ -523,19 +523,19 @@ export const SpeechServiceForm = ({ credential }: SpeechServiceFormProps) => {
                 onChange={(e) => setSttRegion(e.target.value)}
               />
               <label htmlFor={`${vendor}_sst_apikey`}>
-                SST API Key {sttCheck && <span>*</span>}
+                SST API key {sttCheck && <span>*</span>}
               </label>
               <Passwd
                 id={`${vendor}_stt_apikey`}
                 required={sttCheck}
                 name={`${vendor}_stt_apikey`}
-                placeholder="STT API Key"
+                placeholder="STT API key"
                 value={sttApiKey ? getObscuredSecret(sttApiKey) : sttApiKey}
                 onChange={(e) => setSttApiKey(e.target.value)}
                 disabled={credential ? true : false}
               />
               <label htmlFor="instance_id">
-                Speech Instance ID {sttCheck && <span>*</span>}
+                Speech instance ID {sttCheck && <span>*</span>}
               </label>
               <input
                 id="instance_id"
@@ -617,7 +617,7 @@ export const SpeechServiceForm = ({ credential }: SpeechServiceFormProps) => {
                 disabled={!useCustomStt}
                 type="text"
                 name="custom_stt_endpoint"
-                placeholder="Custom speech endpoint id"
+                placeholder="Custom speech endpoint ID"
                 value={customSttEndpoint}
                 onChange={(e) => setCustomSttEndpoint(e.target.value)}
               />

--- a/src/containers/internal/views/speech-services/index.tsx
+++ b/src/containers/internal/views/speech-services/index.tsx
@@ -91,7 +91,7 @@ export const SpeechServices = () => {
   return (
     <>
       <section className="mast">
-        <H1 className="h2">Speech Services</H1>
+        <H1 className="h2">Speech services</H1>
         <Link to={`${ROUTE_INTERNAL_SPEECH}/add`} title="Add a speech service">
           <Icon>
             <Icons.Plus />


### PR DESCRIPTION
I have applied the same capitalization rule to all app: "only the first word in a phrase should be capitalized".
I also changed "SIP trunk" appearing in one place. We call them Carriers in our new app in all other places.

I have found that the terms "SIP Diversion Header", "SIP Register", "MS Teams Direct Routing" are exceptions since they are supposed to be capitalized in the "Voice world".

What about "SIP from user" and "SIP from domain"?

I have also solved that warning coming up in the console regarding autocompleting the passwords.
Other console errors were due to my own Chrome extension. After disabling it they were gone, so unrelated to the webapp.