### PR TITLE
Fix fuzzy search to match against toLowerCase strings

### DIFF
--- a/src/utils/use-filtered-results.ts
+++ b/src/utils/use-filtered-results.ts
@@ -11,7 +11,7 @@ const fuzzyMatch = (patterns: string[], items: string[]) => {
 
   return searchableItems.find((item) => {
     return patterns.some((patternPart) => {
-      return item.toLowerCase().includes(patternPart);
+      return item.toLowerCase().includes(patternPart.toLowerCase());
     });
   });
 };

--- a/src/utils/use-filtered-results.ts
+++ b/src/utils/use-filtered-results.ts
@@ -11,7 +11,7 @@ const fuzzyMatch = (patterns: string[], items: string[]) => {
 
   return searchableItems.find((item) => {
     return patterns.some((patternPart) => {
-      return item.includes(patternPart);
+      return item.toLowerCase().includes(patternPart);
     });
   });
 };


### PR DESCRIPTION
In user lists, a fuzzy search was not really accurate when it came to searching by name, since names can have different capitalizations. This PR fixes this issue.