### PR TITLE
Bug/fix recent calls refresh account assign

### DIFF
--- a/src/components/select-filter.tsx
+++ b/src/components/select-filter.tsx
@@ -40,11 +40,11 @@ export const SelectFilter = ({
           value={filterValue}
           onChange={(e) => {
             setFilterValue(e.target.value);
-            const advancedFilter = createFilterString(
+            const queryFilter = createFilterString(
               e.target.value,
               label as string
             );
-            setQueryFilter(advancedFilter);
+            setQueryFilter(queryFilter);
 
             if (handleSelect) {
               handleSelect(e);

--- a/src/containers/internal/views/alerts/index.tsx
+++ b/src/containers/internal/views/alerts/index.tsx
@@ -65,7 +65,8 @@ export const Alerts = () => {
   useMemo(() => {
     if (getQueryFilter()) {
       const [date] = getQueryFilter().split("/");
-      setAccountSid(getAccountFilter());
+      setAccountSid(getAccountFilter() || accountSid);
+      if (!accountSid && user?.account_sid) setAccountSid(user?.account_sid);
       setDateFilter(date);
     }
   }, [accountSid]);

--- a/src/containers/internal/views/applications/index.tsx
+++ b/src/containers/internal/views/applications/index.tsx
@@ -72,9 +72,9 @@ export const Applications = () => {
     setLocation();
     if (user?.account_sid && user.scope === USER_ACCOUNT) {
       setAccountSid(user?.account_sid);
+    } else {
+      setAccountSid(getAccountFilter() || accountSid);
     }
-
-    setAccountSid(getAccountFilter() || accountSid);
 
     if (accountSid) {
       setApiUrl(`Accounts/${accountSid}/Applications`);

--- a/src/containers/internal/views/applications/index.tsx
+++ b/src/containers/internal/views/applications/index.tsx
@@ -74,7 +74,7 @@ export const Applications = () => {
       setAccountSid(user?.account_sid);
     }
 
-    setAccountSid(getAccountFilter());
+    setAccountSid(getAccountFilter() || accountSid);
 
     if (accountSid) {
       setApiUrl(`Accounts/${accountSid}/Applications`);

--- a/src/containers/internal/views/recent-calls/index.tsx
+++ b/src/containers/internal/views/recent-calls/index.tsx
@@ -81,12 +81,13 @@ export const RecentCalls = () => {
   useMemo(() => {
     if (getQueryFilter()) {
       const [date, direction, status] = getQueryFilter().split("/");
-      setAccountSid(getAccountFilter());
+      setAccountSid(getAccountFilter() || accountSid);
+      if (!accountSid && user?.account_sid) setAccountSid(user?.account_sid);
       setDateFilter(date);
       setDirectionFilter(direction);
       setStatusFilter(status);
     }
-  }, [accountSid]);
+  }, [accountSid, pageNumber]);
 
   useEffect(() => {
     setLocation();

--- a/src/store/localStore.ts
+++ b/src/store/localStore.ts
@@ -39,7 +39,7 @@ export const removeAccountFilter = () => {
  * Methods to get/set the RecentCalls and Alerts selected filters from local storage
  */
 
-const storeQueryFilter = "advancedFilter";
+const storeQueryFilter = "queryFilter";
 
 export const setQueryFilter = (combinedFilterString: string) => {
   return localStorage.setItem(storeQueryFilter, combinedFilterString);
@@ -50,7 +50,7 @@ export const getQueryFilter = () => {
   return localStorage.getItem(storeQueryFilter) || "";
 };
 
-export const removeAdvancedFilter = () => {
+export const removeQueryFilter = () => {
   return localStorage.removeItem(storeQueryFilter);
 };
 


### PR DESCRIPTION
@davehorton I found a few more issues with the persistent implementation where the accountSid was not always assigned. 

This was mostly related to account user recentCalls/ Alerts views.
page switch when Recent calls is more then the 25 that fit on the page.
Some cleanup in naming.