### PR TITLE
Upgrade legacy app with new node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:18.12.1-alpine3.16 as base
+FROM --platform=linux/amd64 node:18.14.0-alpine3.16 as base
 
 RUN apk --update --no-cache add --virtual .builds-deps build-base curl python3
 


### PR DESCRIPTION
This PR upgrades node base image to node:18.14.0-alpine3.16

This fixes:
Critical vulnerability:
CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')

High vulnerability:
CWE-416: Double Free
CWE-416: Use After Free