### PR TITLE
Add env VITE_APP_DISABLE_DEFAULT_TRUNK_ROUTING

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,6 @@ VITE_DEV_BASE_URL=http://127.0.0.1:3000/v1
 
 ## enables choosing units and lisenced account call limits
 # VITE_APP_ENABLE_ACCOUNT_LIMITS_ALL=true
+
+# disables controls for default application routing to carrier for SP and account level users
+#VITE_APP_DISABLE_DEFAULT_TRUNK_ROUTING=true

--- a/src/containers/internal/views/carriers/form.tsx
+++ b/src/containers/internal/views/carriers/form.tsx
@@ -45,6 +45,7 @@ import {
   isUserAccountScope,
   hasLength,
   isValidPort,
+  disableDefaultTrunkRouting,
 } from "src/utils";
 
 import type {
@@ -725,18 +726,21 @@ export const CarrierForm = ({
                     : false
                 }
               />
-              {accountSid && hasLength(applications) && (
-                <>
-                  <ApplicationSelect
-                    label="Default Application"
-                    defaultOption="None"
-                    application={[applicationSid, setApplicationSid]}
-                    applications={applications.filter(
-                      (application) => application.account_sid === accountSid
-                    )}
-                  />
-                </>
-              )}
+              {user &&
+                disableDefaultTrunkRouting(user?.scope) &&
+                accountSid &&
+                hasLength(applications) && (
+                  <>
+                    <ApplicationSelect
+                      label="Default Application"
+                      defaultOption="None"
+                      application={[applicationSid, setApplicationSid]}
+                      applications={applications.filter(
+                        (application) => application.account_sid === accountSid
+                      )}
+                    />
+                  </>
+                )}
             </fieldset>
             <fieldset>
               <Checkzone

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -225,6 +225,17 @@ export const createFilterString = (filterValue: string, label: string) => {
   return filterString.join("/");
 };
 
+export const disableDefaultTrunkRouting = (userScope: UserData["scope"]) => {
+  if (import.meta.env.VITE_APP_DISABLE_DEFAULT_TRUNK_ROUTING) {
+    if (userScope === USER_ADMIN) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+  return true;
+};
+
 export {
   withSuspense,
   useMobileMedia,


### PR DESCRIPTION
This PR adds the option to disable Default Application options to prevent SP and Account level users from configuring a default route to an application if needed.

Env VITE_APP_DISABLE_DEFAULT_TRUNK_ROUTING will hide "Default application" dropdown in Carrier Edit form when Account in "Used by" field is selected.