### PR TITLE
bug/two-clicks for logout

### DIFF
--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -189,6 +189,7 @@ export const CRED_NOT_TESTED = "not tested";
 
 /** API base paths */
 export const API_LOGIN = `${API_BASE_URL}/login`;
+export const API_LOGOUT = `${API_BASE_URL}/logout`;
 export const API_SBCS = `${API_BASE_URL}/Sbcs`;
 export const API_USERS = `${API_BASE_URL}/Users`;
 export const API_API_KEYS = `${API_BASE_URL}/ApiKeys`;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -18,6 +18,7 @@ import {
   API_SIP_GATEWAY,
   API_PASSWORD_SETTINGS,
   USER_ACCOUNT,
+  API_LOGOUT,
 } from "./constants";
 import { ROUTE_LOGIN } from "src/router/routes";
 import {
@@ -231,6 +232,10 @@ export const postLogin = (payload: UserLoginPayload) => {
       "Content-Type": "application/json",
     },
   });
+};
+
+export const postLogout = () => {
+  return postFetch<undefined>(API_LOGOUT);
 };
 
 /** Named wrappers for `postFetch` */

--- a/src/router/auth.tsx
+++ b/src/router/auth.tsx
@@ -148,6 +148,10 @@ export const useProvideAuth = (): AuthStateContext => {
           }
         })
         .catch((error) => {
+          localStorage.clear();
+          sessionStorage.clear();
+          sessionStorage.setItem(SESS_FLASH_MSG, MSG_LOGGED_OUT);
+          window.location.href = ROUTE_LOGIN;
           if (error) {
             reject(error);
           }

--- a/src/router/auth.tsx
+++ b/src/router/auth.tsx
@@ -4,13 +4,13 @@
 import React, { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { postLogin } from "src/api";
+import { postLogin, postLogout } from "src/api";
 import { StatusCodes } from "src/api/types";
 import {
-  ROUTE_LOGIN,
   ROUTE_CREATE_PASSWORD,
   ROUTE_INTERNAL_ACCOUNTS,
   ROUTE_INTERNAL_APPLICATIONS,
+  ROUTE_LOGIN,
 } from "./routes";
 import {
   SESS_OLD_PASSWORD,
@@ -136,10 +136,24 @@ export const useProvideAuth = (): AuthStateContext => {
   };
 
   const signout = () => {
-    localStorage.clear();
-    sessionStorage.clear();
-    sessionStorage.setItem(SESS_FLASH_MSG, MSG_LOGGED_OUT);
-    window.location.href = ROUTE_LOGIN;
+    return new Promise((resolve, reject) => {
+      postLogout()
+        .then((response) => {
+          if (response.status === StatusCodes.OK) {
+            localStorage.clear();
+            sessionStorage.clear();
+            sessionStorage.setItem(SESS_FLASH_MSG, MSG_LOGGED_OUT);
+            window.location.href = ROUTE_LOGIN;
+            resolve(response.json);
+          }
+        })
+        .catch((error) => {
+          if (error) {
+            reject(error);
+          }
+          reject(MSG_SOMETHING_WRONG);
+        });
+    });
   };
 
   return {

--- a/src/router/auth.tsx
+++ b/src/router/auth.tsx
@@ -137,13 +137,13 @@ export const useProvideAuth = (): AuthStateContext => {
 
   const signout = () => {
     return new Promise((resolve, reject) => {
+      window.location.href = ROUTE_LOGIN;
       postLogout()
         .then((response) => {
           if (response.status === StatusCodes.OK) {
             localStorage.clear();
             sessionStorage.clear();
             sessionStorage.setItem(SESS_FLASH_MSG, MSG_LOGGED_OUT);
-            window.location.href = ROUTE_LOGIN;
             resolve(response.json);
           }
         })


### PR DESCRIPTION
This was a behavior caused by adding the /logout call to Signout button/function, where you needed to press "Signout" two times to be redirected to Login page, but the token was already unauthorized, so you saw the error in the console.
