### PR TITLE
fix the webapp blocking account name if exists in anohter SP

### DIFF
--- a/src/containers/internal/navi/index.tsx
+++ b/src/containers/internal/navi/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo } from "react";
 import { classNames, M, Icon, Button } from "@jambonz/ui-kit";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import { Icons, ModalForm } from "src/components";
 import { naviTop, naviByo } from "./items";
@@ -20,6 +20,7 @@ import "./styles.scss";
 import { ScopedAccess } from "src/components/scoped-access";
 import { Scope, UserData } from "src/store/types";
 import { USER_ADMIN } from "src/api/constants";
+import { ROUTE_LOGIN } from "src/router/routes";
 
 type CommonProps = {
   handleMenu: () => void;
@@ -61,6 +62,7 @@ export const Navi = ({
   handleLogout,
 }: NaviProps) => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const user = useSelectState("user");
   const accessControl = useSelectState("accessControl");
   const serviceProviders = useSelectState("serviceProviders");
@@ -160,6 +162,7 @@ export const Navi = ({
                 onChange={(e) => {
                   setSid(e.target.value);
                   setActiveSP(e.target.value);
+                  navigate(ROUTE_LOGIN);
                 }}
                 disabled={user?.scope !== USER_ADMIN}
               >

--- a/src/containers/internal/views/accounts/form.tsx
+++ b/src/containers/internal/views/accounts/form.tsx
@@ -158,7 +158,14 @@ export const AccountForm = ({ apps, limits, account }: AccountFormProps) => {
           ? accounts.filter((a) => a.account_sid !== account.data!.account_sid)
           : accounts;
 
-      if (filtered.find((a) => a.name === name)) {
+      if (
+        account &&
+        filtered.find(
+          (a) =>
+            a.service_provider_sid !== account.data!.service_provider_sid &&
+            a.name === name
+        )
+      ) {
         setMessage(
           "The name you have entered is already in use on another one of your accounts."
         );

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -55,7 +55,7 @@ export const isValidPasswd = (
       password.length >= passwordSettings?.min_password_length &&
       (passwordSettings?.require_digit ? /\d/.test(password) : true) &&
       (passwordSettings?.require_special_character
-        ? /[!@#$%^&*(),.?"';:{}|<>+~]/.test(password)
+        ? /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password)
         : true)
     );
   }


### PR DESCRIPTION
When as admin you were trying to add Account with the same name as account in a different SP it was failing.

How to test:

1. login as admin
2. create another SP
3. try creating an account with the same name as an account in the default SP

I also added a hard reload when changing service provider in the dropdown.
When you were in an edit form or so, when changing SP it was staying within the form causing a wrong fetch. 

Also, enhanced the password check to be same as in api-server regarding the special chars.