### PR TITLE
Feature: Allow windows to npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
   ],
   "scripts": {
     "prepare": "husky install",
-    "postinstall": "rm -rf public/fonts && cp -R node_modules/@jambonz/ui-kit/public/fonts public/fonts",
+    "postinstall:nix": "rm -rf public/fonts && cp -R node_modules/@jambonz/ui-kit/public/fonts public/fonts",
+    "postinstall:windows": "if exist .\\public\\fonts rmdir .\\public\\fonts /s /q  && mkdir .\\public\\fonts && copy .\\node_modules\\@jambonz\\ui-kit\\public\\fonts\\ .\\public\\fonts\\",
     "start": "npm run dev",
     "dev": "vite --port 3001",
     "dev:server": "ts-node --esm server/dev.server.ts",
-    "prebuild": "rm -rf ./dist",
+    "prebuild:nix": "rm -rf ./dist",
+    "prebuild:windows": "if exist .\\dist rmdir /q /s .\\dist",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --max-warnings=0",
@@ -73,7 +75,8 @@
     "serve": "^14.0.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.6.3",
-    "vite": "^3.0.0"
+    "vite": "^3.0.0",
+    "run-script-os": "^1.1.6"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --max-warnings=0",


### PR DESCRIPTION
Currently due to cmd's such as `rm` and `cp`  being in the npm scripts us pesky Window's users cant run or build.

Added `run-script-os` as a dev dependency to selectively run scripts based on os.