### PR TITLE
fix: unchecked checkzone still render input with required

### DIFF
--- a/src/components/forms/checkzone/index.tsx
+++ b/src/components/forms/checkzone/index.tsx
@@ -63,7 +63,7 @@ export const Checkzone = forwardRef<CheckzoneRef, CheckzoneProps>(
           />
           <div>{label}</div>
         </label>
-        <div className={classesIn}>{children}</div>
+        {checked && <div className={classesIn}>{children}</div>}
       </div>
     );
   }


### PR DESCRIPTION
#241 

Hi @davehorton 

The issue is that the unchecked checkzone still redener input with required class.

fixed it by, if it's unchecked checkzone, no redender for all children component.