### PR TITLE
fix default value for elevenlab optimize_streaming_latency

### DIFF
--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -213,7 +213,7 @@ export const GOOGLE_CUSTOM_VOICES_REPORTED_USAGE = [
 ];
 // Eleven Labs options
 export const DEFAULT_ELEVENLABS_OPTIONS: Partial<ElevenLabsOptions> = {
-  optimize_streaming_latency: 100,
+  optimize_streaming_latency: 3,
   voice_settings: {
     stability: 0.5,
     similarity_boost: 0.5,


### PR DESCRIPTION
0 - default mode (no latency optimizations)
1 - normal latency optimizations (about 50% of possible latency improvement of option 3) 
2 - strong latency optimizations (about 75% of possible latency improvement of option 3) 
3 - max latency optimizations 
4 - max latency optimizations, but also with text normalizer turned off for even more latency savings (best latency, but can mispronounce eg numbers and dates).