### PR TITLE
Add support for both legacy jaeger and latest otel trace formats

### DIFF
--- a/src/api/jaeger-types.ts
+++ b/src/api/jaeger-types.ts
@@ -4,7 +4,8 @@ export interface JaegerRoot {
 
 export interface JaegerResourceSpan {
   resource: JaegerResource;
-  instrumentationLibrarySpans: InstrumentationLibrarySpan[];
+  instrumentationLibrarySpans?: InstrumentationLibrarySpan[];
+  scopeSpans?: ScopeSpan[];
 }
 
 export interface JaegerResource {
@@ -16,7 +17,17 @@ export interface InstrumentationLibrarySpan {
   spans: JaegerSpan[];
 }
 
+export interface ScopeSpan {
+  scope: Scope;
+  spans: JaegerSpan[];
+}
+
 export interface InstrumentationLibrary {
+  name: string;
+  version: string;
+}
+
+export interface Scope {
   name: string;
   version: string;
 }

--- a/src/containers/internal/views/recent-calls/utils.ts
+++ b/src/containers/internal/views/recent-calls/utils.ts
@@ -3,9 +3,25 @@ import { JaegerAttribute, JaegerRoot, JaegerSpan } from "src/api/jaeger-types";
 export const getSpansFromJaegerRoot = (trace: JaegerRoot) => {
   const spans: JaegerSpan[] = [];
   trace.resourceSpans.forEach((resourceSpan) => {
-    resourceSpan.instrumentationLibrarySpans.forEach(
-      (instrumentationLibrarySpan) => {
-        instrumentationLibrarySpan.spans.forEach((value) => {
+    if (resourceSpan.instrumentationLibrarySpans) {
+      resourceSpan.instrumentationLibrarySpans.forEach(
+        (instrumentationLibrarySpan) => {
+          instrumentationLibrarySpan.spans.forEach((value) => {
+            const attrs = value.attributes.filter(
+              (attr) =>
+                !(
+                  attr.key.startsWith("telemetry") ||
+                  attr.key.startsWith("internal")
+                ),
+            );
+            value.attributes = attrs;
+            spans.push(value);
+          });
+        },
+      );
+    } else if (resourceSpan.scopeSpans) {
+      resourceSpan.scopeSpans.forEach((scopeSpan) => {
+        scopeSpan.spans.forEach((value) => {
           const attrs = value.attributes.filter(
             (attr) =>
               !(
@@ -16,8 +32,8 @@ export const getSpansFromJaegerRoot = (trace: JaegerRoot) => {
           value.attributes = attrs;
           spans.push(value);
         });
-      },
-    );
+      });
+    }
   });
   spans.sort((a, b) => a.startTimeUnixNano - b.startTimeUnixNano);
   return spans;


### PR DESCRIPTION
Added support to the front end so it supports the legacy Jaeger format and the new otel format returned by the latest versions of Jaeger. 