### PR TITLE
Disable password managers on some password forms

### DIFF
--- a/src/components/forms/passwd/index.tsx
+++ b/src/components/forms/passwd/index.tsx
@@ -32,7 +32,7 @@ export const Passwd = forwardRef<PasswdRef, PasswdProps>(
       <div className="passwd">
         <input
           autoComplete="off"
-          data-lpignore=true
+          data-lpignore="true"
           ref={ref}
           type={reveal ? "text" : "password"}
           name={name}

--- a/src/components/forms/passwd/index.tsx
+++ b/src/components/forms/passwd/index.tsx
@@ -31,7 +31,8 @@ export const Passwd = forwardRef<PasswdRef, PasswdProps>(
     return (
       <div className="passwd">
         <input
-          autoComplete={"off"}
+          autoComplete="off"
+          data-lpignore=true
           ref={ref}
           type={reveal ? "text" : "password"}
           name={name}

--- a/src/components/forms/passwd/index.tsx
+++ b/src/components/forms/passwd/index.tsx
@@ -8,6 +8,8 @@ type PasswdProps = JSX.IntrinsicElements["input"] & {
   locked?: boolean;
   /** This is optional in case an onChange override is necessary... */
   setValue?: React.Dispatch<React.SetStateAction<string>>;
+  /** Whether to ignore password managers */
+  ignorePasswordManager?: boolean;
 };
 
 type PasswdRef = HTMLInputElement;
@@ -22,17 +24,27 @@ export const Passwd = forwardRef<PasswdRef, PasswdProps>(
       setValue,
       placeholder,
       locked = false,
+      ignorePasswordManager = true,
       ...restProps
     }: PasswdProps,
     ref,
   ) => {
     const [reveal, setReveal] = useState(false);
 
+    // Create object with conditional password manager attributes
+    const passwordManagerAttributes = ignorePasswordManager
+      ? {
+          "data-lpignore": "true",
+          "data-1p-ignore": "",
+          "data-form-type": "other",
+          "data-bwignore": "",
+        }
+      : {};
+
     return (
       <div className="passwd">
         <input
           autoComplete="off"
-          data-lpignore="true"
           ref={ref}
           type={reveal ? "text" : "password"}
           name={name}
@@ -44,6 +56,7 @@ export const Passwd = forwardRef<PasswdRef, PasswdProps>(
             }
           }}
           {...restProps}
+          {...passwordManagerAttributes}
         />
         {!locked && (
           <button

--- a/src/containers/login/login.tsx
+++ b/src/containers/login/login.tsx
@@ -99,6 +99,7 @@ export const Login = () => {
           value={password}
           placeholder="Password"
           setValue={setPassword}
+          ignorePasswordManager={false}
         />
         {message && <Message message={message} />}
         <Button type="submit">Log in</Button>


### PR DESCRIPTION
add the data-lpignore attribute to the password component and remove redundant {} on autoComplete.

This should resolve the recurring issue we've had with users having issues creating a carrier where the page was expecting an SMPP IP adddress, that issue seemed to be that lastpass was adding their jambonz password as an SMPP password so the form validation expected an SMPP IP to go with the credentials.

By default lastpass don't honor the autocompete=off attribute unless you change your settings but they also have this aditional attribute which should then ignore the field for all lastpass users 
https://support.lastpass.com/s/document-item?language=en_US&bundleId=lastpass&topicId=LastPass/c_lp_prevent_fields_from_being_filled_automatically.html&_LANG=enus