### PR TITLE
don't remove storeAlertsLastViewed on logout

### DIFF
--- a/src/router/auth.tsx
+++ b/src/router/auth.tsx
@@ -173,7 +173,7 @@ export const useProvideAuth = (): AuthStateContext => {
           }
         })
         .catch((error) => {
-          localStorage.clear();
+          clearLocalStorage();
           sessionStorage.clear();
           sessionStorage.setItem(SESS_FLASH_MSG, MSG_LOGGED_OUT);
           window.location.href = ROUTE_LOGIN;

--- a/src/store/localStore.ts
+++ b/src/store/localStore.ts
@@ -145,7 +145,7 @@ export const checkLocation = () => {
 };
 
 export const clearLocalStorage = () => {
-  const toKeep = [storeActiveSP, storeAccountFilter];
+  const toKeep = [storeActiveSP, storeAccountFilter, storeAlertsLastViewed];
   Object.keys(localStorage).forEach((key) => {
     if (!toKeep.includes(key)) {
       localStorage.removeItem(key);


### PR DESCRIPTION
keep the AlertsLastViewed param in localStorage on a logout so that the alerts badge doesn't re-appear on next login